### PR TITLE
Paths dependent on install (Drupal vs standalone)

### DIFF
--- a/pl_attach-library.function.php
+++ b/pl_attach-library.function.php
@@ -14,6 +14,17 @@ $function = new Twig_SimpleFunction('attach_library', function ($string) {
   $yamlFile = glob('*.libraries.yml');
   $yamlOutput = Yaml::parseFile($yamlFile[0]);
 
+  $directoryPath = explode('/', dirname(__FILE__));
+
+  $rootPathString = '';
+  // If the themes directory is in the path (Drupal).
+  if (in_array('themes', $directoryPath)) {
+    $rootPathLocation = array_search('themes', $directoryPath);
+    $themePathOffset = -1 * (count($directoryPath) - array_search('components', $directoryPath));
+    $rootPath = array_slice($directoryPath, $rootPathLocation, $themePathOffset, true);
+    $rootPathString = implode('/', $rootPath) . '/';
+  }
+
   // For each item in .libraries.yml file.
   foreach($yamlOutput as $key => $value) {
 
@@ -22,7 +33,7 @@ $function = new Twig_SimpleFunction('attach_library', function ($string) {
       $files = $yamlOutput[$key]['js'];
       // For each file, create an async script to insert to the Twig component.
       foreach($files as $key => $jsPath) {
-        $scriptString = '<script async src="/' . $key . '"></script>';
+        $scriptString = '<script async src="/' . $rootPathString . $key . '"></script>';
         $stringLoader = \PatternLab\Template::getStringLoader();
         $output = $stringLoader->render(array("string" => $scriptString, "data" => []));
         return $output;


### PR DESCRIPTION
If you're running Pattern Lab inside of Drupal (e.g., `DRUPAL/themes/contrib/emulsify/pattern-lab/public/`), the paths determined by this extension are different. This tries to fix the broken ones in Drupal while keeping it working in standalone Emulsify installations