### PR TITLE
Fix for external JS paths being broken by attach_library

### DIFF
--- a/pl_attach-library.function.php
+++ b/pl_attach-library.function.php
@@ -21,8 +21,14 @@ $function = new Twig_SimpleFunction('attach_library', function ($string) {
     if ($key === $libraryName) {
       $files = $yamlOutput[$key]['js'];
       // For each file, create an async script to insert to the Twig component.
-      foreach($files as $key => $jsPath) {
-        $scriptString = '<script async src="/' . $key . '"></script>';
+      foreach($files as $key => $file) {
+        // By default prefix paths with a /, but remove this for external JS
+        // as it would break URLs.
+        $path_prefix = '/';
+        if (isset($file['type']) && $file['type'] === 'external') {
+          $path_prefix = '';
+        }
+        $scriptString = '<script src="' . $path_prefix . $key . '"></script>';
         $stringLoader = \PatternLab\Template::getStringLoader();
         $output = $stringLoader->render(array("string" => $scriptString, "data" => []));
         return $output;

--- a/pl_attach-library.function.php
+++ b/pl_attach-library.function.php
@@ -28,7 +28,7 @@ $function = new Twig_SimpleFunction('attach_library', function ($string) {
         if (isset($file['type']) && $file['type'] === 'external') {
           $path_prefix = '';
         }
-        $scriptString = '<script src="' . $path_prefix . $key . '"></script>';
+        $scriptString = '<script data-name="reload" src="' . $path_prefix . $key . '"></script>';
         $stringLoader = \PatternLab\Template::getStringLoader();
         $output = $stringLoader->render(array("string" => $scriptString, "data" => []));
         return $output;

--- a/pl_attach-library.function.php
+++ b/pl_attach-library.function.php
@@ -28,7 +28,7 @@ $function = new Twig_SimpleFunction('attach_library', function ($string) {
         if (isset($file['type']) && $file['type'] === 'external') {
           $path_prefix = '';
         }
-        $scriptString = '<script data-name="reload" src="' . $path_prefix . $key . '"></script>';
+        $scriptString = '<script data-name="reload" data-src="/' . $path_prefix . $key . '"></script>';
         $stringLoader = \PatternLab\Template::getStringLoader();
         $output = $stringLoader->render(array("string" => $scriptString, "data" => []));
         return $output;

--- a/pl_attach-library.function.php
+++ b/pl_attach-library.function.php
@@ -28,7 +28,7 @@ $function = new Twig_SimpleFunction('attach_library', function ($string) {
         if (isset($file['type']) && $file['type'] === 'external') {
           $path_prefix = '';
         }
-        $scriptString = '<script data-name="reload" data-src="/' . $path_prefix . $key . '"></script>';
+        $scriptString = '<script data-name="reload" data-src="' . $path_prefix . $key . '"></script>';
         $stringLoader = \PatternLab\Template::getStringLoader();
         $output = $stringLoader->render(array("string" => $scriptString, "data" => []));
         return $output;


### PR DESCRIPTION
A quick attempt at fixing #3

Only prefixes JS paths with a `/` if the JS is not `type: external`