### PR TITLE
Add ability to attach library stylesheets and/or scripts

### DIFF
--- a/pl_attach-library.function.php
+++ b/pl_attach-library.function.php
@@ -1,10 +1,12 @@
 <?php
+
 /**
  * @file
  * Add "attach_library" function for Pattern Lab.
  */
 
 use Symfony\Component\Yaml\Yaml;
+use PatternLab\Template;
 
 $function = new Twig_SimpleFunction('attach_library', function ($string) {
   // Get Library Name from string.
@@ -16,13 +18,13 @@ $function = new Twig_SimpleFunction('attach_library', function ($string) {
   $scriptTags = [];
 
   // For each item in .libraries.yml file.
-  foreach($yamlOutput as $key => $value) {
+  foreach ($yamlOutput as $key => $value) {
 
     // If the library exists.
     if ($key === $libraryName) {
       $files = $yamlOutput[$key]['js'];
       // For each file, create an async script to insert to the Twig component.
-      foreach($files as $key => $file) {
+      foreach ($files as $key => $file) {
         // By default prefix paths with a /, but remove this for external JS
         // as it would break URLs.
         $path_prefix = '/';
@@ -30,11 +32,11 @@ $function = new Twig_SimpleFunction('attach_library', function ($string) {
           $path_prefix = '';
         }
         $scriptString = '<script data-name="reload" data-src="' . $path_prefix . $key . '"></script>';
-        $stringLoader = \PatternLab\Template::getStringLoader();
-        $scriptTags[$key] = $stringLoader->render(array("string" => $scriptString, "data" => []));
-    	}
+        $stringLoader = Template::getStringLoader();
+        $scriptTags[$key] = $stringLoader->render(["string" => $scriptString, "data" => []]);
+      }
     }
   }
 
   return implode($scriptTags);
-}, array('is_safe' => array('html')));
+}, ['is_safe' => ['html']]);


### PR DESCRIPTION
Makes it possible to attach local or external css files even if in multiple groups.

Library file like this should work in all instances:

```yml
accordion:
  js:
    dist/02-molecules/accordion-item/accordion-item.js: {}
  css:
    theme:
      dist/02-molecules/accordion-item/accordion-item.css: {}

icons:
  css:
    base:
      https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css { type: external }
    theme:
      dist/01-base/04-images/icons/icons.css: {}

mobile_menu:
  css:
    base:
      dist/02-molecules/menus/mobile-menu.css: {}

slideout_menu:
  js:
    https://cdnjs.cloudflare.com/ajax/libs/slideout/1.0.1/slideout.min.js { type: external }

```
      

