### PR TITLE
Create JS library paths relative to HTML

### DIFF
--- a/pl_attach-library.function.php
+++ b/pl_attach-library.function.php
@@ -25,7 +25,7 @@ $function = new Twig_SimpleFunction('attach_library', function ($string) {
       foreach($files as $key => $file) {
         // By default prefix paths with a /, but remove this for external JS
         // as it would break URLs.
-        $path_prefix = '/';
+        $path_prefix = '../../../../';
         if (isset($file['type']) && $file['type'] === 'external') {
           $path_prefix = '';
         }


### PR DESCRIPTION
## TL;DR
This PR modifies the `attach_library` function to produce JS library paths that are relative to the generated component HTML documents, rather than to the root of the site.

## (Long-winded) Background
We’re using Emulsify and have CI automatically building a static version of Pattern Lab so developers and stakeholders can review the patterns on the live environment. This saves us having to keep a separate Node process running to serve from the theme directory. We access the pattern library via a URL that looks like this:
```
https://project-domain.com/themes/custom/THEME_NAME/pattern-lab/public
```

To accomplish this, our deployment script simply navigates to the theme directory, installs dependencies, and invokes a script that builds static files, like so:
```sh
cd web/themes/custom/THEME_NAME && npm ci --usafe-perm && npm run build
```

Where the `build` script in our theme’s `package.json` is as follows:
```js
"scripts": {
  "build": "gulp build",
  // other scripts
}
```

Note that `gulp build` simply invokes [this task in `emulsify-gulp`](https://github.com/fourkitchens/emulsify-gulp/blob/451cd766d34f515ee4e2c4ec4bedda43ce53a036/index.js#L144). The result is a navigable set of static Pattern Lab files that point to `../../../../dist/style.css` for CSS and `script` tags that point to `/dist/path_to_component/component_name.js`, i.e. while CSS paths are relative to the HTML document, JS paths are relative to the root of the site.

To illustrate the problem with this in our scenario, here’s that sample URL again with some notes:
```
                                                   ▼ dist/ lives at this level
https://project-domain.com/themes/custom/THEME_NAME/pattern-lab/public
                          ▲ <script> tags are written as if it lived here
```

Note that using paths relative to the root of the site works correctly when serving Pattern Lab from the theme directory (i.e. when using `npm start`) because `dist/` happens to be at the root level in that context. However, this is brittle, because it requires Pattern Lab to be served from the theme directory in order for JS paths to work.

This PR addresses this problem by producing JS library paths that, much like the `style.css` path, are relative to the component’s HTML file, and not to the root of the site, which enables us to access Pattern Lab in the way described above while continuing to support the server run by Emulsify’s `npm start`.